### PR TITLE
Add sad path tests to RecipeRepo and User

### DIFF
--- a/test/RecipeRepository-test.js
+++ b/test/RecipeRepository-test.js
@@ -475,7 +475,15 @@ describe('RecipeRepository', () => {
     expect(recipeRepo.filteredByName('Elvis Pancakes')[0]).to.deep.equal(recipeData[3])
   });
 
+  it('should return an empty array when name search results in no match', () => {
+    expect(recipeRepo.filteredByName('Ryan\'s famouse chili')).to.deep.equal([])
+  });
+
   it('should have a method that searches recipes by tag ', () => {
     expect(recipeRepo.filteredByTag('side dish')).to.deep.equal([recipeData[3]])
+  });
+
+  it('should return an empty array when tag search results in no match', () => {
+    expect(recipeRepo.filteredByTag('Midnight Snack')).to.deep.equal([])
   });
 })

--- a/test/User-test.js
+++ b/test/User-test.js
@@ -409,10 +409,20 @@ describe('User', () => {
     expect(newUser.filterRecipesToCookByName('Loaded Chocolate Chip Pudding Cookie Cups')).to.deep.equal([recipeObject1])
   })
 
+  it('Should return an empty array when name search results in no match', () => {
+    newUser.recipesToCook.push(recipeObject1)
+    expect(newUser.filterRecipesToCookByName('Ryan\'s famous chili')).to.deep.equal([])
+  })
+
   it('Should be able to filter the recipiesToCook array by tag', () => {
     newUser.recipesToCook.push(recipeObject1)
     newUser.filterRecipesToCookByTag('snack')
     expect(newUser.filterRecipesToCookByTag('snack')).to.deep.equal([recipeObject1])
+  })
+
+  it('Should return an empty array when tag search results in no match', () => {
+    newUser.recipesToCook.push(recipeObject1)
+    expect(newUser.filterRecipesToCookByTag('Midnight Snack')).to.deep.equal([])
   })
 
   it('Should have a name', () => {


### PR DESCRIPTION
ISSUES: #61 

____ Wrote Tests ____ Implemented ____ Reviewed

Necessary checkmarks:

[X] All Tests are Passing

[X] The code will run locally

Type of change

[X] New feature
[] Bug Fix

Implements/Fixes:

This adds sad path testing to the search and filter functions of both recipe-repo-test and user-test files.

Check the correct boxes

[x] This broke nothing
[] This broke some stuff
[] This broke everything

Testing Changes

[] No Tests have been changed
[x] Some Tests have been changed
[] All of the Tests have been changed(Please describe what in the world happened)

Checklist:

[x] My code has no unused/commented out code
[x] I have reviewed my code
[] I have commented my code, particularly in hard-to-understand areas
[x] I have fully tested my code
